### PR TITLE
[#11] 토큰 파싱 과정이 누락된 문제 해결

### DIFF
--- a/src/main/kotlin/com/github/jwt/security/ReactiveJwtFilter.kt
+++ b/src/main/kotlin/com/github/jwt/security/ReactiveJwtFilter.kt
@@ -16,7 +16,7 @@ class ReactiveJwtFilter(
         Mono.justOrEmpty(exchange.request.headers.getFirst(HttpHeaders.AUTHORIZATION))
             .filter { it.startsWith("Bearer ") }
             .switchIfEmpty { Mono.error(IllegalArgumentException("Authorization header is invalid.")) }
-            .map { jwtProvider.getAuthentication(it) }
+            .map { jwtProvider.getAuthentication(it.substring(7)) }
             .flatMap {
                 chain.filter(exchange)
                     .contextWrite(ReactiveSecurityContextHolder.withAuthentication(it))


### PR DESCRIPTION
## 작업 내용

* **`ReactiveJwtFilter`에서 `substring()`을 사용해 토큰을 파싱하도록 수정**

## 관련 이슈

* **Close #11**