### PR TITLE
[#15] ReactiveJwtFilter에서 비즈니스 계층의 예외도 처리되던 문제 해결

### DIFF
--- a/src/main/kotlin/com/github/jwt/core/JwtProvider.kt
+++ b/src/main/kotlin/com/github/jwt/core/JwtProvider.kt
@@ -1,5 +1,6 @@
 package com.github.jwt.core
 
+import com.github.jwt.exception.jwtExceptionCatching
 import com.github.jwt.security.JwtAuthentication
 import io.jsonwebtoken.Claims
 import io.jsonwebtoken.Jwts
@@ -20,19 +21,23 @@ class JwtProvider(
         createToken(authentication.toClaims(), refreshTokenExpire)
 
     fun getAuthentication(token: String): JwtAuthentication =
-        Jwts.parserBuilder()
-            .setSigningKey(secretKey)
-            .build()
-            .parseClaimsJws(token)
-            .body
-            .toAuthentication()
+        jwtExceptionCatching {
+            Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .body
+                .toAuthentication()
+        }
 
-    private fun createToken(claims: Claims, expire: Long): String =
-        Date().let {
+    fun createToken(claims: Claims, expire: Long): String =
+        jwtExceptionCatching {
+            val now = Date()
+
             Jwts.builder()
                 .setClaims(claims)
-                .setIssuedAt(it)
-                .setExpiration(Date(it.time + expire))
+                .setIssuedAt(now)
+                .setExpiration(Date(now.time + expire))
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact()
         }

--- a/src/main/kotlin/com/github/jwt/exception/ExceptionHandler.kt
+++ b/src/main/kotlin/com/github/jwt/exception/ExceptionHandler.kt
@@ -1,0 +1,6 @@
+package com.github.jwt.exception
+
+fun <T> jwtExceptionCatching(init: () -> T) =
+    runCatching(init)
+        .onFailure { throw JwtException(it.message) }
+        .getOrThrow()

--- a/src/main/kotlin/com/github/jwt/exception/JwtException.kt
+++ b/src/main/kotlin/com/github/jwt/exception/JwtException.kt
@@ -1,0 +1,5 @@
+package com.github.jwt.exception
+
+data class JwtException(
+    override val message: String?
+) : RuntimeException(message)

--- a/src/main/kotlin/com/github/jwt/security/JwtFilter.kt
+++ b/src/main/kotlin/com/github/jwt/security/JwtFilter.kt
@@ -19,9 +19,8 @@ class JwtFilter(
         val header = request.getHeader(HttpHeaders.AUTHORIZATION)
 
         if (header.startsWith("Bearer ")) {
-            val authentication = jwtProvider.getAuthentication(header.substring(7))
-
-            SecurityContextHolder.getContext().authentication = authentication
+            runCatching { jwtProvider.getAuthentication(header.substring(7)) }
+                .onSuccess { SecurityContextHolder.getContext().authentication = it }
         }
 
         return filterChain.doFilter(request, response)

--- a/src/main/kotlin/com/github/jwt/security/ReactiveJwtFilter.kt
+++ b/src/main/kotlin/com/github/jwt/security/ReactiveJwtFilter.kt
@@ -1,12 +1,14 @@
 package com.github.jwt.security
 
 import com.github.jwt.core.JwtProvider
+import com.github.jwt.exception.JwtException
 import org.springframework.http.HttpHeaders
 import org.springframework.security.core.context.ReactiveSecurityContextHolder
 import org.springframework.web.server.ServerWebExchange
 import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.onErrorResume
 import reactor.kotlin.core.publisher.switchIfEmpty
 
 class ReactiveJwtFilter(
@@ -15,11 +17,11 @@ class ReactiveJwtFilter(
     override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> =
         Mono.justOrEmpty(exchange.request.headers.getFirst(HttpHeaders.AUTHORIZATION))
             .filter { it.startsWith("Bearer ") }
-            .switchIfEmpty { Mono.error(IllegalArgumentException("Authorization header is invalid.")) }
+            .switchIfEmpty { Mono.error(JwtException("Authorization header is invalid.")) }
             .map { jwtProvider.getAuthentication(it.substring(7)) }
             .flatMap {
                 chain.filter(exchange)
                     .contextWrite(ReactiveSecurityContextHolder.withAuthentication(it))
             }
-            .onErrorResume { chain.filter(exchange) }
+            .onErrorResume(JwtException::class) { chain.filter(exchange) }
 }

--- a/src/test/kotlin/com/github/jwt/JwtProviderTest.kt
+++ b/src/test/kotlin/com/github/jwt/JwtProviderTest.kt
@@ -1,9 +1,9 @@
 package com.github.jwt
 
+import com.github.jwt.exception.JwtException
 import com.github.jwt.fixture.INVALID_TOKEN
 import com.github.jwt.fixture.createJwtAuthentication
 import com.github.jwt.fixture.jwtProvider
-import io.jsonwebtoken.JwtException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.equals.shouldBeEqual


### PR DESCRIPTION
## 작업 내용

* **JWT 예외 처리 구현**
* **`JwtFilter` 및 `ReactiveJwtFilter`에서 `JwtException`에 대해서만 예외 처리를 수행하도록 구현**

## 관련 이슈

* **Close #15**