### PR TITLE
[#21] JWT 관련 유틸 메서드들을 패키지 외부에서도 사용할 수 있도록 수정

### DIFF
--- a/src/main/kotlin/com/github/jwt/util/JwtUtil.kt
+++ b/src/main/kotlin/com/github/jwt/util/JwtUtil.kt
@@ -15,7 +15,7 @@ import javax.crypto.SecretKey
  * @param minute Minute as a [Long]
  * @return milliseconds as a [Long]
  */
-internal fun minutesToMillis(minute: Long): Long = TimeUnit.MINUTES.toMillis(minute)
+fun minutesToMillis(minute: Long): Long = TimeUnit.MINUTES.toMillis(minute)
 
 /**
  * Method to retrieve bearer token from header.
@@ -23,7 +23,7 @@ internal fun minutesToMillis(minute: Long): Long = TimeUnit.MINUTES.toMillis(min
  * @receiver Header string
  * @return Token as a [String]
  */
-internal fun String.toBearerToken(): Token =
+fun String.toBearerToken(): Token =
     if (startsWith("Bearer ")) substring(7) else throw JwtException("Authorization header is invalid.")
 
 /**
@@ -32,7 +32,7 @@ internal fun String.toBearerToken(): Token =
  * @receiver Secret string
  * @return Secret key
  */
-internal fun String.toSecretKey(): SecretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(this))
+fun String.toSecretKey(): SecretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(this))
 
 /**
  * Method to convert header to map.
@@ -40,7 +40,7 @@ internal fun String.toSecretKey(): SecretKey = Keys.hmacShaKeyFor(Decoders.BASE6
  * @receiver Header
  * @return [Map]
  */
-internal fun Header<*>.toMap(): Map<String, String> =
+fun Header<*>.toMap(): Map<String, String> =
     entries.associate { it.key to it.value.toString() }
 
 /**
@@ -49,5 +49,5 @@ internal fun Header<*>.toMap(): Map<String, String> =
  * @receiver Payload
  * @return [Map]
  */
-internal fun Claims.toMap(): Map<String, String> =
+fun Claims.toMap(): Map<String, String> =
     entries.associate { it.key to it.value.toString() }


### PR DESCRIPTION
## 작업 내용

* **JWT 유틸 메서드에 `internal` 접근 제어자 삭제**

## 관련 이슈

* **Close #21**